### PR TITLE
Clean up specified directories during user deletion

### DIFF
--- a/src/index.mjs
+++ b/src/index.mjs
@@ -330,7 +330,7 @@ for (const u of newUsers) {
 await Promise.all(
   newUsers.map(async (u) => Promise.all(
     config.managed_user_directories.map(async (d) => {
-      const formatdir = d.replace("%u", users[u].username).replace("%U", users[u].uid);
+      const formatdir = d.replace("%u", configUsers[u].username).replace("%U", configUsers[u].uid);
       await $`mkdir -p ${formatdir}`;
     })
   ))

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -267,6 +267,11 @@ for (const u of usersToDelete) {
 await Promise.all(
   usersToDelete.map(async (u) => {
     await $`rm -rf ${config.user_ssh_key_base_dir}/${u}`;
+    return Promise.all(
+      config.directories.map(async (d) => {
+        await $`rm -rf ${d}/${u}`;
+      })
+    )
   })
 );
 console.timeLog("userdel")

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -337,8 +337,6 @@ await Promise.all(
 )
 console.timeLog("useradd")
 
-
-
 console.log(`Updating user properties for ${usermodArgs.length} users...`);
 console.time("usermod")
 for (const args of usermodArgs) {

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -266,11 +266,11 @@ for (const u of usersToDelete) {
 // delete SSH keys
 await Promise.all(
   usersToDelete.map(async (u) => {
-    let sshdir = config.user_ssh_key_base_dir.replace("%u", users[u].username).replace("%U", users[u].uid);
+    const sshdir = config.user_ssh_key_base_dir.replace("%u", users[u].username).replace("%U", users[u].uid);
     await $`rm -rf ${sshdir}`;
     return Promise.all(
       config.directories.map(async (d) => {
-        let formatdir = d.replace("%u", users[u].username).replace("%U", users[u].uid);
+        const formatdir = d.replace("%u", users[u].username).replace("%U", users[u].uid);
         await $`rm -rf ${formatdir}`;
       })
     )

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -266,10 +266,10 @@ for (const u of usersToDelete) {
 // delete SSH keys
 await Promise.all(
   usersToDelete.map(async (u) => {
-    await $`rm -rf ${config.user_ssh_key_base_dir}/${u}`;
+    await $`rm -rf ${config.user_ssh_key_base_dir}`;
     return Promise.all(
       config.directories.map(async (d) => {
-        await $`rm -rf ${d}/${u}`;
+        await $`rm -rf ${d}`;
       })
     )
   })

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -324,7 +324,18 @@ for (const u of newUsers) {
 
   await $`useradd ${args} ${u}`;
 }
+// create dirs for new users
+await Promise.all(
+  newUsers.map(async (u) => Promise.all(
+    config.managed_user_directories.map(async (d) => {
+      const formatdir = d.replace("%u", users[u].username).replace("%U", users[u].uid);
+      await $`mkdir -p ${formatdir}`;
+    })
+  ))
+)
 console.timeLog("useradd")
+
+
 
 console.log(`Updating user properties for ${usermodArgs.length} users...`);
 console.time("usermod")

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -269,7 +269,7 @@ await Promise.all(
     const sshdir = config.user_ssh_key_base_dir.replace("%u", users[u].username).replace("%U", users[u].uid);
     await $`rm -rf ${sshdir}`;
     return Promise.all(
-      config.directories.map(async (d) => {
+      config.managed_user_directories.map(async (d) => {
         const formatdir = d.replace("%u", users[u].username).replace("%U", users[u].uid);
         await $`rm -rf ${formatdir}`;
       })

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -266,10 +266,12 @@ for (const u of usersToDelete) {
 // delete SSH keys
 await Promise.all(
   usersToDelete.map(async (u) => {
-    await $`rm -rf ${config.user_ssh_key_base_dir}`;
+    let sshdir = config.user_ssh_key_base_dir.replace("%u", users[u].username).replace("%U", users[u].uid);
+    await $`rm -rf ${sshdir}`;
     return Promise.all(
       config.directories.map(async (d) => {
-        await $`rm -rf ${d}`;
+        let formatdir = d.replace("%u", users[u].username).replace("%U", users[u].uid);
+        await $`rm -rf ${formatdir}`;
       })
     )
   })

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -268,6 +268,11 @@ await Promise.all(
   usersToDelete.map(async (u) => {
     const sshdir = config.user_ssh_key_base_dir.replace("%u", users[u].username).replace("%U", users[u].uid);
     await $`rm -rf ${sshdir}`;
+  })
+);
+// delete managed dirs
+await Promise.all(
+  usersToDelete.map(async (u) => {
     return Promise.all(
       config.managed_user_directories.map(async (d) => {
         const formatdir = d.replace("%u", users[u].username).replace("%U", users[u].uid);
@@ -275,7 +280,8 @@ await Promise.all(
       })
     )
   })
-);
+)
+
 console.timeLog("userdel")
 
 console.log(`Deleting ${groupsToDelete.length} groups...`);

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -272,14 +272,13 @@ await Promise.all(
 );
 // delete managed dirs
 await Promise.all(
-  usersToDelete.map(async (u) => {
-    return Promise.all(
+  usersToDelete.map(async (u) => Promise.all(
       config.managed_user_directories.map(async (d) => {
         const formatdir = d.replace("%u", users[u].username).replace("%U", users[u].uid);
         await $`rm -rf ${formatdir}`;
       })
     )
-  })
+  )
 )
 
 console.timeLog("userdel")

--- a/src/schema.mjs
+++ b/src/schema.mjs
@@ -104,7 +104,7 @@ export const configSchema = {
     },
     managed_user_directories: {
       type: "array",
-      description: "List of directories to delete automatically. Supports templating with $u (username) and %U (uid)",
+      description: "List of directories to delete automatically. Supports templating with %u (username) and %U (uid)",
       items: { type: "string" },
     },
     use_strict_ssh_key_dir_permissions: {

--- a/src/schema.mjs
+++ b/src/schema.mjs
@@ -106,6 +106,7 @@ export const configSchema = {
       type: "array",
       description: "List of directories to create and delete automatically for each user. Supports templating with %u (username) and %U (uid)",
       items: { type: "string" },
+      default: [],
     },
     use_strict_ssh_key_dir_permissions: {
       type: "boolean",

--- a/src/schema.mjs
+++ b/src/schema.mjs
@@ -102,6 +102,11 @@ export const configSchema = {
       description: "Base directory for user SSH keys. Supports templating with %u (username) and %U (uid)",
       default: "/home/%u/.ssh",
     },
+    directories: {
+      type: "array",
+      description: "List of directories to delete automatically.",
+      items: { type: "string" },
+    },
     use_strict_ssh_key_dir_permissions: {
       type: "boolean",
       description: "If true, the provisioner will manage the SSH key directory permissions such that the user can read/execute the directory, but not write to the directory.",

--- a/src/schema.mjs
+++ b/src/schema.mjs
@@ -104,7 +104,7 @@ export const configSchema = {
     },
     managed_user_directories: {
       type: "array",
-      description: "List of directories to delete automatically. Supports templating with %u (username) and %U (uid)",
+      description: "List of directories to create and delete automatically for each user. Supports templating with %u (username) and %U (uid)",
       items: { type: "string" },
     },
     use_strict_ssh_key_dir_permissions: {

--- a/src/schema.mjs
+++ b/src/schema.mjs
@@ -102,9 +102,9 @@ export const configSchema = {
       description: "Base directory for user SSH keys. Supports templating with %u (username) and %U (uid)",
       default: "/home/%u/.ssh",
     },
-    directories: {
+    managed_user_directories: {
       type: "array",
-      description: "List of directories to delete automatically.",
+      description: "List of directories to delete automatically. Supports templating with $u (username) and %U (uid)",
       items: { type: "string" },
     },
     use_strict_ssh_key_dir_permissions: {


### PR DESCRIPTION
Closes #1.
I decided to add a directories property to the config object so the the script can remove multiple directories. I could instead use a constant in the script that specifies the directories that need to be deleted, but I thought it would be inconsistent.