### PR TITLE
Handle permissions properly for managed user directories

### DIFF
--- a/integration-tests/utils.ts
+++ b/integration-tests/utils.ts
@@ -1,0 +1,14 @@
+import { StartedTestContainer } from "testcontainers";
+
+export async function ensurePermissions(container: StartedTestContainer, path: string, expected: string) {
+    const { stdout, stderr, exitCode } = await container.exec(["stat", "--format", "%a %U %G", path]);
+    expect(exitCode).toBe(0);
+    expect(stderr.trim()).toBe("");
+    expect(stdout.trim()).toBe(expected);
+}
+
+export async function ensureNotExists(container: StartedTestContainer, path: string) {
+    const { stderr, exitCode } = await container.exec(["stat", path]);
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("No such file or directory");
+}

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -331,7 +331,9 @@ await Promise.all(
   newUsers.map(async (u) => Promise.all(
     config.managed_user_directories.map(async (d) => {
       const formatdir = d.replace("%u", configUsers[u].username).replace("%U", configUsers[u].uid);
-      await $`mkdir -p ${formatdir}`;
+      await $`mkdir -p -m u=rwx,g=rx,o=rx ${formatdir}`;
+      await $`chmod 700 ${formatdir}`;
+      await $`chown ${configUsers[u].uid}:${configUsers[u].primary_group} ${formatdir}`;
     })
   ))
 )

--- a/src/schema.mjs
+++ b/src/schema.mjs
@@ -104,7 +104,7 @@ export const configSchema = {
     },
     managed_user_directories: {
       type: "array",
-      description: "List of directories to create and delete automatically for each user. Supports templating with %u (username) and %U (uid)",
+      description: "List of directories to create and delete automatically for each user. Supports templating with %u (username) and %U (uid). The script will create the directory with permissions 700 and ownership of the user. If not already existing, directories leading up to the directory will be created with permissions 755 and ownership of the provisioner user.",
       items: { type: "string" },
       default: [],
     },


### PR DESCRIPTION
This PR is a follow-up to #6 , to explicitly set permissions of the created directories. This allows users to access the directories created (previously they can't access it lol).

cc @WATonomous/watonomous-watcloud-reviewers 