### PR TITLE
Use generic versioning in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Tool to provision Linux users and groups. Useful for provisioning a large number
 1. Prepare a configuration file in the format specified in [src/schema.mjs](./src/schema.mjs).
 2. Run the following command to run the provisioner:
 ```bash
-npx @watonomous/linux-directory-provisioner@v0.0.4-alpha.1 --config=path_to_config.json
+npx @watonomous/linux-directory-provisioner@^0.0.4-alpha --config=path_to_config.json
 ```
 
 ## Publishing to NPM


### PR DESCRIPTION
Previously, we had to change the README for every version bump. This PR changes it so that we use a matching character `^` instead.