### PR TITLE
Simplify SSH key management

### DIFF
--- a/integration-tests/basic.test.ts
+++ b/integration-tests/basic.test.ts
@@ -278,7 +278,14 @@ describe("Basic", () => {
             expect(exitCode).toBe(0);
         }
 
-        // Check SSH keys
+        // Check that the keys exist
+        await ensureExists(container, "/tmp/ssh-keys/user1/1001/.ssh/authorized_keys");
+        await ensureNotExists(container, "/tmp/ssh-keys/user2/1002/.ssh/authorized_keys");
+
+        // Check permissions
+        await ensurePermissions(container, "/tmp/ssh-keys/user1/1001/.ssh/authorized_keys", "600 user1 user1");
+
+        // Check content
         {
             const { output, stdout, stderr, exitCode } = await container.exec(["cat", "/tmp/ssh-keys/user1/1001/.ssh/authorized_keys"]);
             expect(exitCode).toBe(0);

--- a/integration-tests/basic.test.ts
+++ b/integration-tests/basic.test.ts
@@ -148,7 +148,7 @@ describe("Basic", () => {
         }
     }, 60000);
 
-    test.only("should not delete home directories by default", async () => {
+    test("should not delete home directories by default", async () => {
         basicConfig.users[0].home_dir = "/tmp/myhome/%u/%U";
         basicConfig.users[1].home_dir = "/tmp/myhome/%u/%U";
         await container.copyContentToContainer([{ content: JSON.stringify(basicConfig), target: "/app/config.json" }]);
@@ -185,6 +185,11 @@ describe("Basic", () => {
             "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDwLVH+sBKaWb09IfaGkyqF9LEds6UN6grSQTieVD0ZW",
             "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDwLVH+sBKaWb09IfaGkyqF9LEds6UN6grSQTieVD0ZW",
         ];
+
+        basicConfig.managed_user_directories = [
+            "/home/%u",
+            "/home/%u/.ssh",
+        ]
 
         await container.copyContentToContainer([{ content: JSON.stringify(basicConfig), target: "/app/config.json" }]);
 
@@ -254,12 +259,16 @@ describe("Basic", () => {
         }
     }, 60000);
 
-    test("should respect user_ssh_key_base_dir", async () => {
-        basicConfig.user_ssh_key_base_dir = "/tmp/ssh-keys/%u/%U/.ssh";
+    test("should allow custom ssh key locations", async () => {
         basicConfig.users[0].ssh_authorized_keys = [
             "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDwLVH+sBKaWb09IfaGkyqF9LEds6UN6grSQTieVD0ZW",
             "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDwLVH+sBKaWb09IfaGkyqF9LEds6UN6grSQTieVD0ZW",
         ];
+        basicConfig.users[0].ssh_authorized_keys_path = "/tmp/ssh-keys/%u/%U/.ssh/authorized_keys";
+
+        basicConfig.managed_user_directories = [
+            "/tmp/ssh-keys/%u/%U/.ssh",
+        ]
 
         await container.copyContentToContainer([{ content: JSON.stringify(basicConfig), target: "/app/config.json" }]);
 
@@ -279,38 +288,7 @@ describe("Basic", () => {
         }
     }, 60000);
 
-    test("should respect use_strict_ssh_key_dir_permissions", async () => {
-        basicConfig.user_ssh_key_base_dir = "/tmp/ssh-keys/%u/%U/.ssh";
-        basicConfig.use_strict_ssh_key_dir_permissions = true;
-        basicConfig.users[0].ssh_authorized_keys = [
-            "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDwLVH+sBKaWb09IfaGkyqF9LEds6UN6grSQTieVD0ZW",
-            "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDwLVH+sBKaWb09IfaGkyqF9LEds6UN6grSQTieVD0ZW",
-        ];
-
-        await container.copyContentToContainer([{ content: JSON.stringify(basicConfig), target: "/app/config.json" }]);
-
-        // Create users and groups
-        {
-            const { output, stdout, stderr, exitCode } = await container.exec(["npx", "--yes", "dist.tgz", "--no-confirm", "--config", "/app/config.json"]);
-            expect(exitCode).toBe(0);
-        }
-
-        // Check folder permissions
-        {
-            const { output, stdout, stderr, exitCode } = await container.exec(["stat", "--format", "%a %U %G", "/tmp/ssh-keys/"]);
-            expect(exitCode).toBe(0);
-            expect(stdout).toContain("755 root root");
-        }
-        {
-            const { output, stdout, stderr, exitCode } = await container.exec(["stat", "--format", "%a %U %G", "/tmp/ssh-keys/user1"]);
-            expect(exitCode).toBe(0);
-            expect(stdout).toContain("750 root group1");
-        }
-    }, 60000);
-
     test("should delete users and groups that have been removed from the config", async () => {
-        basicConfig.user_ssh_key_base_dir = "/tmp/ssh-keys/%u/%U/.ssh";
-
         await container.copyContentToContainer([{ content: JSON.stringify(basicConfig), target: "/app/config.json" }]);
 
         // Create users and groups
@@ -341,11 +319,6 @@ describe("Basic", () => {
             expect(exitCode).toBe(0);
             expect(stdout).not.toContain("group2");
         }
-        {
-            const { output, stdout, stderr, exitCode } = await container.exec(["stat", "/tmp/ssh-keys/user2/1002/.ssh"]);
-            expect(exitCode).toBe(1);
-            expect(stderr).toContain("No such file or directory");
-        }
     }, 60000);
 
     test("should create and delete managed user directories", async () => {
@@ -371,7 +344,6 @@ describe("Basic", () => {
     
         {
             const { output, stdout, stderr, exitCode } = await container.exec(["npx", "--yes", "dist.tgz", "--no-confirm", "--config", "/app/config.json"]);
-            console.log(output, stdout, stderr)
             expect(exitCode).toBe(0);
             expect(stdout).toContain("Creating managed user directories for 0 user(s)...")
         }

--- a/integration-tests/basic.test.ts
+++ b/integration-tests/basic.test.ts
@@ -199,6 +199,13 @@ describe("Basic", () => {
             expect(exitCode).toBe(0);
         }
 
+        // Check that the appropriate keys exist
+        await ensureExists(container, "/home/user1/.ssh/authorized_keys");
+        await ensureNotExists(container, "/home/user2/.ssh/authorized_keys");
+
+        // Check permissions
+        await ensurePermissions(container, "/home/user1/.ssh/authorized_keys", "600 user1 group1");
+
         // Check SSH keys
         {
             const { output, stdout, stderr, exitCode } = await container.exec(["cat", "/home/user1/.ssh/authorized_keys"]);
@@ -278,12 +285,12 @@ describe("Basic", () => {
             expect(exitCode).toBe(0);
         }
 
-        // Check that the keys exist
+        // Check that the appropriate keys exist
         await ensureExists(container, "/tmp/ssh-keys/user1/1001/.ssh/authorized_keys");
         await ensureNotExists(container, "/tmp/ssh-keys/user2/1002/.ssh/authorized_keys");
 
         // Check permissions
-        await ensurePermissions(container, "/tmp/ssh-keys/user1/1001/.ssh/authorized_keys", "600 user1 user1");
+        await ensurePermissions(container, "/tmp/ssh-keys/user1/1001/.ssh/authorized_keys", "600 user1 group1");
 
         // Check content
         {

--- a/integration-tests/basic.test.ts
+++ b/integration-tests/basic.test.ts
@@ -216,6 +216,21 @@ describe("Basic", () => {
         }
     }, 60000);
 
+    test.only("should throw an error if the parent directory of the ssh key location does not exist", async () => {
+        basicConfig.users[0].ssh_authorized_keys_path = "/tmp/ssh-keys/%u/%U/.ssh/authorized_keys";
+        basicConfig.users[0].ssh_authorized_keys = [
+            "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDwLVH+sBKaWb09IfaGkyqF9LEds6UN6grSQTieVD0ZW",
+        ];
+        await container.copyContentToContainer([{ content: JSON.stringify(basicConfig), target: "/app/config.json" }]);
+        
+        // Create users and groups
+        {
+            const { output, stdout, stderr, exitCode } = await container.exec(["npx", "--yes", "dist.tgz", "--no-confirm", "--config", "/app/config.json"]);
+            expect(exitCode).toBe(1);
+            expect(stderr).toContain("No such file or directory");
+        }
+    }, 60000);
+
     test("should set custom shell correctly", async () => {
         basicConfig.users[0].shell = "/bin/zsh";
 

--- a/integration-tests/basic.test.ts
+++ b/integration-tests/basic.test.ts
@@ -216,7 +216,7 @@ describe("Basic", () => {
         }
     }, 60000);
 
-    test.only("should throw an error if the parent directory of the ssh key location does not exist", async () => {
+    test("should throw an error if the parent directory of the ssh key location does not exist", async () => {
         basicConfig.users[0].ssh_authorized_keys_path = "/tmp/ssh-keys/%u/%U/.ssh/authorized_keys";
         basicConfig.users[0].ssh_authorized_keys = [
             "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDwLVH+sBKaWb09IfaGkyqF9LEds6UN6grSQTieVD0ZW",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@watonomous/linux-directory-provisioner",
-  "version": "0.0.5-alpha.1",
+  "version": "0.0.5-alpha.2",
   "description": "A tool to provision linux users and groups",
   "main": "dist/index.mjs",
   "bin": {

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -326,7 +326,7 @@ for (const u of newUsers) {
     "--shell",
     configUsers[u].shell,
     "--home",
-    configUsers[u].home_dir.replaceAll("%u", u).replaceAll("%U", configUsers[u].uid),
+    configUsers[u].home_dir,
   ];
 
   if (configUsers[u].additional_groups.length > 0) {

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -376,6 +376,8 @@ await Promise.all(
     // Write the SSH keys
     await $`echo "# This file is managed by the Linux Directory Provisioner. Please do not modify it manually." > ${keysPath}`;
     await $`echo ${configSSHAuthorizedKeys[username].join("\n")} >> ${keysPath}`;
+    await $`chown ${configUsers[username].uid}:${configUsers[username].primary_group} ${keysPath}`;
+    await $`chmod 600 ${keysPath}`;
   })
 );
 console.timeLog("sshauthorizedkeys")

--- a/src/schema.mjs
+++ b/src/schema.mjs
@@ -46,7 +46,11 @@ const userSchema = {
     password: { type: "string" },
     update_password: { enum: ["always", "on_create"] },
     uid: { type: "number" },
-    home_dir: { type: "string", description: "Home directory for the user. Supports templating with %u (username) and %U (uid). If not specified, the default will be the system default (e.g. `/home/%u` on most Linux distributions)" },
+    home_dir: { 
+      type: "string",
+      default: "/home/%u",
+      description: "Home directory for the user. Supports templating with %u (username) and %U (uid). Defaults to `/home/%u`."
+    },
     primary_group: { type: "string" },
     additional_groups: {
       type: "array",
@@ -56,6 +60,10 @@ const userSchema = {
     },
     shell: { type: "string", default: "/bin/bash" },
     ssh_authorized_keys: { type: "array", items: { type: "string" }, default: [] },
+    ssh_authorized_keys_path: {
+      type: "string",
+      description: "Path to the SSH authorized keys file. Supports templating with %u (username) and %U (uid). Defaults to `<home_dir>/.ssh/authorized_keys` where `<home_dir>` is the value of the `home_dir` property."
+    },
     linger: { type: "boolean", default: false },
     disk_quota: {
       type: "array",
@@ -97,11 +105,6 @@ export const configSchema = {
       items: { type: "number" },
       minItems: 2,
       maxItems: 2,
-    },
-    user_ssh_key_base_dir: {
-      type: "string",
-      description: "Base directory for user SSH keys. Supports templating with %u (username) and %U (uid)",
-      default: "/home/%u/.ssh",
     },
     managed_user_directories: {
       type: "array",

--- a/src/utils.mjs
+++ b/src/utils.mjs
@@ -100,7 +100,7 @@ export function parseConfig(config) {
   const configUpdatePassword = Object.fromEntries(config.users.map((u) => [u.username, u.update_password]));
   const configPasswords = Object.fromEntries(config.users.map((u) => [u.username, u.password]));
   const configSSHAuthorizedKeys = Object.fromEntries(config.users.map((u) => [u.username, u.ssh_authorized_keys]));
-  const configSSHAuthorizedKeysPath = Object.fromEntries(config.users.map((u) => [u.username, u.ssh_authorized_keys_path ?? path.join(u.home_dir, ".ssh", "authorized_keys").replace(/%u/g, u.username).replace(/%U/g, u.uid)]));
+  const configSSHAuthorizedKeysPath = Object.fromEntries(config.users.map((u) => [u.username, (u.ssh_authorized_keys_path ?? path.join(u.home_dir, ".ssh", "authorized_keys")).replace(/%u/g, u.username).replace(/%U/g, u.uid)]));
   const configLinger = Object.fromEntries(config.users.map((u) => [u.username, u.linger]));
   const configManagedDirectoriesPerUser = Object.fromEntries(config.users.map((u) => [u.username, config.managed_user_directories.map(d => d.replace(/%u/g, u.username).replace(/%U/g, u.uid))]));
   // Object of the form { <path>: { <uid>: { ...quotaConfig } } }

--- a/src/utils.test.mjs
+++ b/src/utils.test.mjs
@@ -110,7 +110,7 @@ describe("getExistingDirectory", () => {
     const originalReadFile = fsPromises.readFile;
     jest.spyOn(fsPromises, "readFile").mockImplementation((path) => {
       if (path === "/etc/passwd") {
-        return Promise.resolve("user1:x:1001:1001:User 1:/home/user1:/bin/bash\nuser2:x:1002:1002:User 2:/home/user2:/bin/bash");
+        return Promise.resolve("user1:x:1001:1001:User 1:/tmp/home/user1:/bin/bash\nuser2:x:1002:1002:User 2:/home/user2:/bin/bash");
       }
       if (path === "/etc/shadow") {
         return Promise.resolve("user1:$6$random_salt$encrypted_password1\nuser2:$6$random_salt$encrypted_password2");
@@ -151,6 +151,7 @@ describe("getExistingDirectory", () => {
           primary_group: "group1",
           additional_groups: ["group3"],
           shell: "/bin/bash",
+          home_dir: "/tmp/home/user1",
         },
         user2: {
           username: "user2",
@@ -158,6 +159,7 @@ describe("getExistingDirectory", () => {
           primary_group: "group2",
           additional_groups: ["group3"],
           shell: "/bin/bash",
+          home_dir: "/home/user2",
         },
       },
       passwords: {


### PR DESCRIPTION
Main changes:

- SSH key paths are now configured per-user instead of per-config. They default to `<home_dir>/.ssh/authorized_keys`.
- Directories leading up to the key path won't be created by default. To create them, use `managed_user_directories`.
- No more janky permission control and logic to infer some common prefix.