### PR TITLE
Reorder deletion operations

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@watonomous/linux-directory-provisioner",
-  "version": "0.0.5-alpha.2",
+  "version": "0.0.5-alpha.3",
   "description": "A tool to provision linux users and groups",
   "main": "dist/index.mjs",
   "bin": {

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -302,16 +302,16 @@ console.timeLog("deleteManagedDirs");
 console.log(`Deleting ${usersToDelete.length} users...`);
 console.time("userdel")
 // delete users
-for (const u of usersToDelete) {
-  await $`userdel ${u}`;
+for (const username of usersToDelete) {
+  await $`userdel ${username}`;
 }
 console.timeLog("userdel")
 
 // MARK: Delete groups
 console.log(`Deleting ${groupsToDelete.length} groups...`);
 console.time("groupdel")
-for (const g of groupsToDelete) {
-  await $`groupdel ${g}`;
+for (const groupname of groupsToDelete) {
+  await $`groupdel ${groupname}`;
 }
 console.timeLog("groupdel")
 

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -280,7 +280,7 @@ console.time("deleteSSHKeys");
 await Promise.all(
   usersToDelete.map(async (username) => {
     const sshAuthorizedKeysPath = configSSHAuthorizedKeysPath[username];
-    await $`rm -rf ${sshAuthorizedKeysPath}`;
+    await $`rm -f ${sshAuthorizedKeysPath}`;
   })
 );
 console.timeLog("deleteSSHKeys");

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -280,7 +280,7 @@ console.time("deleteSSHKeys");
 await Promise.all(
   usersToDelete.map(async (username) => {
     const sshAuthorizedKeysPath = configSSHAuthorizedKeysPath[username];
-    await $`rm -f ${sshAuthorizedKeysPath}`;
+    await $`rm -rf ${sshAuthorizedKeysPath}`;
   })
 );
 console.timeLog("deleteSSHKeys");


### PR DESCRIPTION
This is so that when the directory deletion operations take too long, they are still applied in the next run. This works because the users being present on the system signals to the script that the user still needs to be deleted.

The motivation of this PR is that this workflow run timed out, and on the next run, the directories are not deleted. https://github.com/WATonomous/infra-config/actions/runs/14687944657/job/41219376118