### PR TITLE
Check for file existence before deletion

### DIFF
--- a/src/index.mjs
+++ b/src/index.mjs
@@ -281,7 +281,7 @@ console.time("deleteSSHKeys");
 await Promise.all(
   usersToDelete.map(async (username) => {
     const sshAuthorizedKeysPath = configSSHAuthorizedKeysPathTemplate.replace(/%u/g, username).replace(/%U/g, users[username].uid);
-    if (sshAuthorizedKeysPath !== undefined) {
+    if (doesPathExist(sshAuthorizedKeysPath)) {
       await $`rm -f ${sshAuthorizedKeysPath}`;
     } else {
       console.warn(`WARNING: No sshAuthorizedKeysPath for user ${username}`);

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -3,7 +3,6 @@
 import './patch.mjs';
 
 import { $, stdin, argv, question } from "zx";
-import { existsSync } from "fs";
 import { readFile } from "node:fs/promises";
 import {
   isLingerSupported,
@@ -17,6 +16,7 @@ import {
   objectMap,
   makeQuotaConfig,
   QUOTA_BLOCK_SIZE,
+  doesPathExist
 } from "./utils.mjs";
 import { validateConfig } from "./schema.mjs";
 
@@ -280,6 +280,7 @@ console.log(`Deleting SSH keys for ${usersToDelete.length} users...`);
 console.time("deleteSSHKeys");
 await Promise.all(
   usersToDelete.map(async (username) => {
+    // TODO: use SSH keys path from config instead of per-user
     const sshAuthorizedKeysPath = configSSHAuthorizedKeysPath[username];
     if (sshAuthorizedKeysPath !== undefined) {
       await $`rm -f ${sshAuthorizedKeysPath}`;
@@ -297,7 +298,7 @@ await Promise.all(
     usersToDelete.map(async (u) => Promise.all(
       config.managed_user_directories.map(async (d) => {
         const formatdir = d.replace("%u", users[u].username).replace("%U", users[u].uid);
-        if (existsSync(formatdir)) {
+        if (doesPathExist(formatdir)) {
           await $`rm -rf ${formatdir}`;
         } else {
           console.warn(`WARNING: Directory doesn't exist for user ${u}: ${formatdir}`);

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -285,7 +285,7 @@ await Promise.all(
     if (sshAuthorizedKeysPath !== undefined) {
       await $`rm -f ${sshAuthorizedKeysPath}`;
     } else {
-      console.warn(`WARNING: No sshAuthorizedKeysPath for user: ${username}`);
+      console.warn(`WARNING: No sshAuthorizedKeysPath for user ${username}`);
     }
   })
 );

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -284,7 +284,7 @@ await Promise.all(
     if (sshAuthorizedKeysPath !== undefined) {
       await $`rm -f ${sshAuthorizedKeysPath}`;
     } else {
-      console.warn(`No sshAuthorizedKeysPath for user: ${username}`);
+      console.warn(`WARNING: No sshAuthorizedKeysPath for user: ${username}`);
     }
   })
 );
@@ -300,7 +300,7 @@ await Promise.all(
         if (existsSync(formatdir)) {
           await $`rm -rf ${formatdir}`;
         } else {
-          console.warn(`Directory doesn't exist for user ${u}: ${formatdir}`);
+          console.warn(`WARNING: Directory doesn't exist for user ${u}: ${formatdir}`);
         }
       })
     )

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -281,7 +281,7 @@ console.time("deleteSSHKeys");
 await Promise.all(
   usersToDelete.map(async (username) => {
     const sshAuthorizedKeysPath = configSSHAuthorizedKeysPathTemplate.replace(/%u/g, username).replace(/%U/g, users[username].uid);
-    if (doesPathExist(sshAuthorizedKeysPath)) {
+    if (await doesPathExist(sshAuthorizedKeysPath)) {
       await $`rm -f ${sshAuthorizedKeysPath}`;
     } else {
       console.warn(`WARNING: No sshAuthorizedKeysPath for user ${username}`);
@@ -297,7 +297,7 @@ await Promise.all(
     usersToDelete.map(async (u) => Promise.all(
       config.managed_user_directories.map(async (d) => {
         const formatdir = d.replace("%u", users[u].username).replace("%U", users[u].uid);
-        if (doesPathExist(formatdir)) {
+        if (await doesPathExist(formatdir)) {
           await $`rm -rf ${formatdir}`;
         } else {
           console.warn(`WARNING: Directory doesn't exist for user ${u}: ${formatdir}`);


### PR DESCRIPTION
Check for file existence before deletion, to deal with the case that the provisioner needs to be run multiple times in order to fully delete the required users

```
TASK [users : Provision directory] *********************************************
ok: [tr-microk8s1]
fatal: [wato-bastion]: FAILED! => {"changed": true, "cmd": ["npx", "--yes", "@watonomous/linux-directory-provisioner@v0.0.5-alpha.3", "--no-confirm", "--config", "-"], "delta": "0:00:02.045768", "end": "2025-04-28 05:14:09.359677", "msg": "non-zero return code", "rc": 1, "start": "2025-04-28 05:14:07.313909", "stderr": "$ rm -f undefined\n$ rm -f undefined\n$ rm -f undefined\n$ rm -f undefined\n$ rm -f undefined\n$ rm -f undefined\n$ rm -f undefined\n$ rm -f undefined\n$ rm -f undefined\n$ rm -f undefined\n$ rm -f undefined\n$ rm -f undefined\n$ rm -f undefined\n$ rm -f undefined\n$ rm -f undefined\n$ rm -f undefined\n$ rm -f undefined\n$ rm -f undefined\n$ rm -f undefined\n$ rm -f undefined\n$ rm -f undefined\n$ rm -f undefined\n$ rm -f undefined\n$ rm -f undefined\n$ rm -f undefined\n$ rm -f undefined\n$ rm -f undefined\n$ rm -f undefined\n$ rm -f undefined\n$ rm -f undefined\n$ rm -f undefined\n$ rm -f undefined\n$ rm -f undefined\n$ rm -f undefined\n$ rm -f undefined\n$ rm -f undefined\n$ rm -f undefined\
```