### PR TITLE
Fix SSH authorized keys deletion

### DIFF
--- a/integration-tests/basic.test.ts
+++ b/integration-tests/basic.test.ts
@@ -212,7 +212,7 @@ describe("Basic", () => {
         }
     }, 60000);
 
-    test("should delete SSH keys whenn deleting users", async () => {
+    test("should delete SSH keys when deleting users", async () => {
         basicConfig.ssh_authorized_keys_path = "/tmp/ssh-keys-%u-%U-authorized_keys";
         basicConfig.users[0].ssh_authorized_keys = [
             "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDwLVH+sBKaWb09IfaGkyqF9LEds6UN6grSQTieVD0ZW",

--- a/integration-tests/basic.test.ts
+++ b/integration-tests/basic.test.ts
@@ -212,6 +212,36 @@ describe("Basic", () => {
         }
     }, 60000);
 
+    test("should delete SSH keys whenn deleting users", async () => {
+        basicConfig.ssh_authorized_keys_path = "/tmp/ssh-keys-%u-%U-authorized_keys";
+        basicConfig.users[0].ssh_authorized_keys = [
+            "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDwLVH+sBKaWb09IfaGkyqF9LEds6UN6grSQTieVD0ZW",
+        ];
+        await container.copyContentToContainer([{ content: JSON.stringify(basicConfig), target: "/app/config.json" }]);
+        
+        // Create users and groups
+        {
+            const { output, stdout, stderr, exitCode } = await container.exec(["npx", "--yes", "dist.tgz", "--no-confirm", "--config", "/app/config.json"]);
+            expect(exitCode).toBe(0);
+        }
+
+        // Check that the appropriate keys exist
+        await ensureExists(container, "/tmp/ssh-keys-user1-1001-authorized_keys");
+        await ensureNotExists(container, "/tmp/ssh-keys-user2-1002-authorized_keys");
+
+        // Delete users and groups
+        basicConfig.users = [];
+        await container.copyContentToContainer([{ content: JSON.stringify(basicConfig), target: "/app/config.json" }]);
+        {
+            const { output, stdout, stderr, exitCode } = await container.exec(["npx", "--yes", "dist.tgz", "--no-confirm", "--config", "/app/config.json"]);
+            expect(exitCode).toBe(0);
+        }
+
+        // Check that the appropriate keys no longer exist
+        await ensureNotExists(container, "/tmp/ssh-keys-user1-1001-authorized_keys");
+        await ensureNotExists(container, "/tmp/ssh-keys-user2-1002-authorized_keys");
+    })
+
     test("should throw an error if the parent directory of the ssh key location does not exist", async () => {
         basicConfig.ssh_authorized_keys_path = "/tmp/ssh-keys/%u/%U/.ssh/authorized_keys";
         basicConfig.users[0].ssh_authorized_keys = [

--- a/integration-tests/basic.test.ts
+++ b/integration-tests/basic.test.ts
@@ -113,8 +113,7 @@ describe("Basic", () => {
     }, 60000);
 
     test("should not create home directories by default", async () => {
-        basicConfig.users[0].home_dir = "/tmp/myhome/%u/%U";
-        basicConfig.users[1].home_dir = "/tmp/myhome/%u/%U";
+        basicConfig.home_dir = "/tmp/myhome/%u/%U";
         await container.copyContentToContainer([{ content: JSON.stringify(basicConfig), target: "/app/config.json" }]);
 
         // Create users and groups
@@ -128,9 +127,7 @@ describe("Basic", () => {
     }, 60000);
 
     test("should support custom home directories", async () => {
-        basicConfig.users[0].home_dir = "/tmp/myhome/%u/%U";
-        basicConfig.users[1].home_dir = "/tmp/myhome/%u/%U";
-
+        basicConfig.home_dir = "/tmp/myhome/%u/%U";
         await container.copyContentToContainer([{ content: JSON.stringify(basicConfig), target: "/app/config.json" }]);
 
         // Create users and groups
@@ -149,8 +146,7 @@ describe("Basic", () => {
     }, 60000);
 
     test("should not delete home directories by default", async () => {
-        basicConfig.users[0].home_dir = "/tmp/myhome/%u/%U";
-        basicConfig.users[1].home_dir = "/tmp/myhome/%u/%U";
+        basicConfig.home_dir = "/tmp/myhome/%u/%U";
         await container.copyContentToContainer([{ content: JSON.stringify(basicConfig), target: "/app/config.json" }]);
 
         // Create users and groups
@@ -217,7 +213,7 @@ describe("Basic", () => {
     }, 60000);
 
     test("should throw an error if the parent directory of the ssh key location does not exist", async () => {
-        basicConfig.users[0].ssh_authorized_keys_path = "/tmp/ssh-keys/%u/%U/.ssh/authorized_keys";
+        basicConfig.ssh_authorized_keys_path = "/tmp/ssh-keys/%u/%U/.ssh/authorized_keys";
         basicConfig.users[0].ssh_authorized_keys = [
             "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDwLVH+sBKaWb09IfaGkyqF9LEds6UN6grSQTieVD0ZW",
         ];
@@ -286,7 +282,7 @@ describe("Basic", () => {
             "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDwLVH+sBKaWb09IfaGkyqF9LEds6UN6grSQTieVD0ZW",
             "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDwLVH+sBKaWb09IfaGkyqF9LEds6UN6grSQTieVD0ZW",
         ];
-        basicConfig.users[0].ssh_authorized_keys_path = "/tmp/ssh-keys/%u/%U/.ssh/authorized_keys";
+        basicConfig.ssh_authorized_keys_path = "/tmp/ssh-keys/%u/%U/.ssh/authorized_keys";
 
         basicConfig.managed_user_directories = [
             "/tmp/ssh-keys/%u/%U/.ssh",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@watonomous/linux-directory-provisioner",
-  "version": "0.0.5-alpha.3",
+  "version": "0.0.6-alpha.1",
   "description": "A tool to provision linux users and groups",
   "main": "dist/index.mjs",
   "bin": {

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -65,11 +65,11 @@ const {
   configUsers,
   configPasswords,
   configSSHAuthorizedKeys,
-  configSSHAuthorizedKeysPath,
   configUpdatePassword,
   configLinger,
   configUserDiskQuota,
   configManagedDirectoriesPerUser,
+  configSSHAuthorizedKeysPathTemplate,
 } = parseConfig(config);
 console.timeLog("parseConfig");
 
@@ -97,7 +97,7 @@ if (usersWithoutPasswords.length > 0) {
 
 console.log("Loading existing SSH authorized keys");
 console.time("getSSHAuthorizedKeys");
-const sshAuthorizedKeys = await getSSHAuthorizedKeys(configSSHAuthorizedKeysPath);
+const sshAuthorizedKeys = await getSSHAuthorizedKeys(configUsers, configSSHAuthorizedKeysPathTemplate);
 console.timeLog("getSSHAuthorizedKeys");
 
 const diskQuotaPaths = unique([...config.xfs_default_user_quota.map(q => q.path), ...Object.keys(configUserDiskQuota)]);
@@ -279,7 +279,7 @@ console.log(`Deleting SSH keys for ${usersToDelete.length} users...`);
 console.time("deleteSSHKeys");
 await Promise.all(
   usersToDelete.map(async (username) => {
-    const sshAuthorizedKeysPath = configSSHAuthorizedKeysPath[username];
+    const sshAuthorizedKeysPath = configSSHAuthorizedKeysPathTemplate.replace(/%u/g, username).replace(/%U/g, users[username].uid);
     await $`rm -f ${sshAuthorizedKeysPath}`;
   })
 );
@@ -391,8 +391,7 @@ console.log(`Updating SSH authorized keys for ${requireSSHAuthorizedKeysUpdate.l
 console.time("sshauthorizedkeys")
 await Promise.all(
   requireSSHAuthorizedKeysUpdate.map(async (username) => {
-
-    const keysPath = configSSHAuthorizedKeysPath[username];
+    const keysPath = configSSHAuthorizedKeysPathTemplate.replace(/%u/g, username).replace(/%U/g, configUsers[username].uid);
 
     // Write the SSH keys
     await $`echo "# This file is managed by the Linux Directory Provisioner. Please do not modify it manually." > ${keysPath}`;

--- a/src/schema.mjs
+++ b/src/schema.mjs
@@ -46,11 +46,6 @@ const userSchema = {
     password: { type: "string" },
     update_password: { enum: ["always", "on_create"] },
     uid: { type: "number" },
-    home_dir: { 
-      type: "string",
-      default: "/home/%u",
-      description: "Home directory for the user. Supports templating with %u (username) and %U (uid). Defaults to `/home/%u`."
-    },
     primary_group: { type: "string" },
     additional_groups: {
       type: "array",
@@ -60,10 +55,6 @@ const userSchema = {
     },
     shell: { type: "string", default: "/bin/bash" },
     ssh_authorized_keys: { type: "array", items: { type: "string" }, default: [] },
-    ssh_authorized_keys_path: {
-      type: "string",
-      description: "Path to the SSH authorized keys file. Supports templating with %u (username) and %U (uid). Defaults to `<home_dir>/.ssh/authorized_keys` where `<home_dir>` is the value of the `home_dir` property."
-    },
     linger: { type: "boolean", default: false },
     disk_quota: {
       type: "array",
@@ -112,10 +103,14 @@ export const configSchema = {
       items: { type: "string" },
       default: [],
     },
-    use_strict_ssh_key_dir_permissions: {
-      type: "boolean",
-      description: "If true, the provisioner will manage the SSH key directory permissions such that the user can read/execute the directory, but not write to the directory.",
-      default: false,
+    home_dir: { 
+      type: "string",
+      default: "/home/%u",
+      description: "Home directory for users. Supports templating with %u (username) and %U (uid). Defaults to `/home/%u`."
+    },
+    ssh_authorized_keys_path: {
+      type: "string",
+      description: "Path to the SSH authorized keys file. Supports templating with %u (username) and %U (uid). Defaults to `<home_dir>/.ssh/authorized_keys` where `<home_dir>` is the value of the `home_dir` property."
     },
     // XFS default quota can be set using `sudo xfs_quota <path> -x -c "limit -d bsoft=<bsoft> bhard=<bhard> isoft=<isoft> ihard=<ihard>"`
     xfs_default_user_quota: {

--- a/src/utils.mjs
+++ b/src/utils.mjs
@@ -1,4 +1,3 @@
-import path from 'path'
 import { readFile, readdir, access } from 'node:fs/promises';
 import { $ } from 'zx';
 
@@ -149,7 +148,7 @@ export function parseConfig(config) {
     return out;
   }, {});
 
-  const configSSHAuthorizedKeysPathTemplate = config.ssh_authorized_keys_path ?? config.home_dir + "/.ssh/authorized_keys";
+  const configSSHAuthorizedKeysPathTemplate = config.ssh_authorized_keys_path ?? `${config.home_dir}/.ssh/authorized_keys`;
 
   return {
     configGroups,

--- a/src/utils.test.mjs
+++ b/src/utils.test.mjs
@@ -79,10 +79,17 @@ describe("diffProperties", () => {
 describe("getSSHAuthorizedKeys", () => {
   // Test case: Getting SSH keys for multiple users
   test("should return SSH keys for multiple users", async () => {
-    const usernameToSSHAuthorizedKeysPath = {
-      "user1": "/home/user1/.ssh/authorized_keys",
-      "user2": "/home/user2/.ssh/authorized_keys"
+    const configUsers = {
+      "user1": {
+        username: "user1",
+        uid: 1001,
+      },
+      "user2": {
+        username: "user2",
+        uid: 1002,
+      }
     }
+    const sshAuthorizedKeysPathTemplate = "/tmp/test/%u/%U/.ssh/authorized_keys";
     const expectedKeys = {
       user1: ["ssh_key1", "ssh_key2"],
       user2: ["ssh_key3", "ssh_key4"],
@@ -90,15 +97,15 @@ describe("getSSHAuthorizedKeys", () => {
 
     // Mock the readFile function
     jest.spyOn(fsPromises, "readFile").mockImplementation((path) => {
-      if (path === "/home/user1/.ssh/authorized_keys") {
+      if (path === "/tmp/test/user1/1001/.ssh/authorized_keys") {
         return Promise.resolve("# some comment\nssh_key1\nssh_key2\n");
       }
-      if (path === "/home/user2/.ssh/authorized_keys") {
+      if (path === "/tmp/test/user2/1002/.ssh/authorized_keys") {
         return Promise.resolve("ssh_key3\n# some comment\nssh_key4\n");
       }
     });
 
-    const result = await getSSHAuthorizedKeys(usernameToSSHAuthorizedKeysPath);
+    const result = await getSSHAuthorizedKeys(configUsers, sshAuthorizedKeysPathTemplate);
     expect(result).toEqual(expectedKeys);
   });
 });


### PR DESCRIPTION
Previously, deleting SSH authorized keys when users were deleted was broken because we used the configuration to infer the key path. The configuration didn't contain deleted users, thus we had no information on where their authorized keys were. This PR relocates the ssh authorized key path specification to the top level, so that it's the same for all users. This allows us to delete SSH keys for users that we want to delete.

Related to #22 . 

Bumping to 0.0.6 because this is a breaking change. The clients need to relocate 2 config (home_dir and ssh_authorized_keys_path to the top level).